### PR TITLE
docs: Create pull_request_template.md

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,21 @@
+# Description
+_provide description here of what the PR is going to do to the code_
+
+# Contributors
+_add all members of the team (using '@' and their github username(s) so they are linked) who contributed to this PR specifically_
+
+# Screenshot(s)
+_add any screenshots that might be useful to whomever is reviewing this PR_
+
+# Notes
+_anything else that doesn't fit in the above categories, but is still important to call out_
+
+# Checklist
+- [ ] My PR has an appropriately descriptive and concise title.
+- [ ] My PR denotes any/all team members who contributed to it.
+- [ ] My code follows the Turing Style Guides and best practices.
+- [ ] I ran the code locally and verified that there are no visible errors.
+- [ ] feat: My PR clearly describes what feature I'm adding and any changes needed to make it work. _(if applicable)_
+- [ ] fix: My PR clearly describes what bug I'm fixing and why. _(if applicable)_
+- [ ] refactor: My PR clearly describes what code I'm refactoring and why. _(if applicable)_
+- [ ] docs: My PR clearly describes which doc(s) I'm updating and why. _(if applicable)_


### PR DESCRIPTION
# Description
- Adds a PR template to the project

# Contributors
@ericahagle 

# Notes
- I've found it really useful to have one of these, and this is the setup I've been using
- I am 100% amenable to switching it up if anyone else has other ideas or formats that they prefer!

# Checklist
- [ ] My PR has an appropriately descriptive and concise title.
- [ ] My PR denotes any/all team members who contributed to it.
- [ ] docs: My PR clearly describes which doc(s) I'm updating and why.