### PR TITLE
test: Add tests and test data for bottom 10s functions

### DIFF
--- a/src/data/testData.js
+++ b/src/data/testData.js
@@ -26,6 +26,96 @@ const users = [
     "strideLength": 2.7,
     "dailyStepGoal": 3000,
     "friends": [31, 16, 15, 7]
+  },
+  {
+    "id": 4,
+    "name": "Evie Satterfield",
+    "address": "1378 Renner Island, Port Lincoln NE 06237-3602",
+    "email": "Adan66@yahoo.com",
+    "strideLength": 3.9,
+    "dailyStepGoal": 4000,
+    "friends": [21, 32, 8]
+  },
+  {
+    "id": 5,
+    "name": "Brycen Rutherford",
+    "address": "0770 Keeley Square, West Keyon SD 73400-6577",
+    "email": "Jerald55@yahoo.com",
+    "strideLength": 3.3,
+    "dailyStepGoal": 10000,
+    "friends": [5, 46]
+  },
+  {
+    "id": 6,
+    "name": "Jillian Senger",
+    "address": "235 Geoffrey Highway, New Lavadaport CA 62933-3709",
+    "email": "Cortez51@gmail.com",
+    "strideLength": 4.3,
+    "dailyStepGoal": 10000,
+    "friends": [25, 15, 20]
+  },
+  {
+    "id": 7,
+    "name": "Elaina Mosciski",
+    "address": "307 Gerhard Pine, Luettgenton NC 60477",
+    "email": "Karolann.Kuvalis@yahoo.com",
+    "strideLength": 3,
+    "dailyStepGoal": 9000,
+    "friends": [7, 46, 43]
+  },
+  {
+    "id": 8,
+    "name": "Amir Lang",
+    "address": "75165 Zulauf Walks, North Dejaview NC 21971-9115",
+    "email": "Eudora.Stracke@yahoo.com",
+    "strideLength": 2.8,
+    "dailyStepGoal": 2000,
+    "friends": [46, 8, 29, 33, 10]
+  },
+  {
+    "id": 9,
+    "name": "Antonina McClure",
+    "address": "480 Niko Village, Thompsonchester GA 94178-0548",
+    "email": "Dustin.Kris15@yahoo.com",
+    "strideLength": 3.5,
+    "dailyStepGoal": 11000,
+    "friends": [26, 7, 39, 3]
+  },
+  {
+    "id": 10,
+    "name": "Dianna Streich",
+    "address": "6383 Barrows Fork, West Stan MS 06434-6341",
+    "email": "Donald_Schiller5@hotmail.com",
+    "strideLength": 3.7,
+    "dailyStepGoal": 5000,
+    "friends": [49, 18, 3, 1]
+  },
+  {
+    "id": 11,
+    "name": "Kailey Langosh",
+    "address": "41048 Mattie Club, North Rickyhaven CO 60210-1389",
+    "email": "Adella2@hotmail.com",
+    "strideLength": 4.3,
+    "dailyStepGoal": 9000,
+    "friends": [26, 17]
+  },
+  {
+    "id": 12,
+    "name": "Jacinthe Prosacco",
+    "address": "9149 Kamille Brook, Josiannehaven TN 49127-4921",
+    "email": "Daniela_Mante86@yahoo.com",
+    "strideLength": 3.5,
+    "dailyStepGoal": 3000,
+    "friends": [5, 17]
+  },
+  {
+    "id": 13,
+    "name": "Seamus Upton",
+    "address": "32689 Eulah View, East Judge TN 06935",
+    "email": "Deontae37@gmail.com",
+    "strideLength": 3.8,
+    "dailyStepGoal": 12000,
+    "friends": [11, 43]
   }
 ];
 
@@ -70,6 +160,56 @@ const hydrationData = [
     "userID": 2,
     "date": "2023/03/30",
     "numOunces": 57
+  },
+  {
+    "userID": 4,
+    "date": "2023/03/24",
+    "numOunces": 74
+  },
+  {
+    "userID": 5,
+    "date": "2023/03/24",
+    "numOunces": 47
+  },
+  {
+    "userID": 6,
+    "date": "2023/03/24",
+    "numOunces": 86
+  },
+  {
+    "userID": 7,
+    "date": "2023/03/24",
+    "numOunces": 74
+  },
+  {
+    "userID": 8,
+    "date": "2023/03/24",
+    "numOunces": 36
+  },
+  {
+    "userID": 9,
+    "date": "2023/03/24",
+    "numOunces": 40
+  },
+  {
+    "userID": 10,
+    "date": "2023/03/24",
+    "numOunces": 49
+  },
+  {
+    "userID": 11,
+    "date": "2023/03/24",
+    "numOunces": 48
+  },
+  {
+    "userID": 12,
+    "date": "2023/03/24",
+    "numOunces": 24
+  },
+  {
+    "userID": 13,
+    "date": "2023/03/24",
+    "numOunces": 97
   }
 ];
 
@@ -123,6 +263,66 @@ const sleepData = [
     "date": "2023/03/30",
     "hoursSlept": 10.1,
     "sleepQuality": 3.2
+  },
+  {
+    "userID": 4,
+    "date": "2023/03/24",
+    "hoursSlept": 4.7,
+    "sleepQuality": 3
+  },
+  {
+    "userID": 5,
+    "date": "2023/03/24",
+    "hoursSlept": 8,
+    "sleepQuality": 3.1
+  },
+  {
+    "userID": 6,
+    "date": "2023/03/24",
+    "hoursSlept": 4.2,
+    "sleepQuality": 1.2
+  },
+  {
+    "userID": 7,
+    "date": "2023/03/24",
+    "hoursSlept": 4.1,
+    "sleepQuality": 3.9
+  },
+  {
+    "userID": 8,
+    "date": "2023/03/24",
+    "hoursSlept": 9.2,
+    "sleepQuality": 1.6
+  },
+  {
+    "userID": 9,
+    "date": "2023/03/24",
+    "hoursSlept": 4.8,
+    "sleepQuality": 2.5
+  },
+  {
+    "userID": 10,
+    "date": "2023/03/24",
+    "hoursSlept": 7.2,
+    "sleepQuality": 2.2
+  },
+  {
+    "userID": 11,
+    "date": "2023/03/24",
+    "hoursSlept": 7.2,
+    "sleepQuality": 1
+  },
+  {
+    "userID": 12,
+    "date": "2023/03/24",
+    "hoursSlept": 4,
+    "sleepQuality": 3.1
+  },
+  {
+    "userID": 13,
+    "date": "2023/03/24",
+    "hoursSlept": 6.5,
+    "sleepQuality": 1.4
   }
 ];
 
@@ -183,6 +383,76 @@ const activityData = [
     "numSteps": 4676,
     "minutesActive": 288,
     "flightsOfStairs": 5
+  },
+  {
+    "userID": 4,
+    "date": "2023/03/24",
+    "numSteps": 8934,
+    "minutesActive": 294,
+    "flightsOfStairs": 19
+  },
+  {
+    "userID": 5,
+    "date": "2023/03/24",
+    "numSteps": 8443,
+    "minutesActive": 136,
+    "flightsOfStairs": 43
+  },
+  {
+    "userID": 6,
+    "date": "2023/03/24",
+    "numSteps": 13297,
+    "minutesActive": 116,
+    "flightsOfStairs": 13
+  },
+  {
+    "userID": 7,
+    "date": "2023/03/24",
+    "numSteps": 7765,
+    "minutesActive": 74,
+    "flightsOfStairs": 31
+  },
+  {
+    "userID": 8,
+    "date": "2023/03/24",
+    "numSteps": 7255,
+    "minutesActive": 42,
+    "flightsOfStairs": 28
+  },
+  {
+    "userID": 9,
+    "date": "2023/03/24",
+    "numSteps": 3801,
+    "minutesActive": 41,
+    "flightsOfStairs": 20
+  },
+  {
+    "userID": 10,
+    "date": "2023/03/24",
+    "numSteps": 2145,
+    "minutesActive": 168,
+    "flightsOfStairs": 1
+  },
+  {
+    "userID": 11,
+    "date": "2023/03/24",
+    "numSteps": 5491,
+    "minutesActive": 172,
+    "flightsOfStairs": 26
+  },
+  {
+    "userID": 12,
+    "date": "2023/03/24",
+    "numSteps": 11616,
+    "minutesActive": 56,
+    "flightsOfStairs": 36
+  },
+  {
+    "userID": 13,
+    "date": "2023/03/24",
+    "numSteps": 11755,
+    "minutesActive": 169,
+    "flightsOfStairs": 12
   }
 ];
 

--- a/test/scripts-test.js
+++ b/test/scripts-test.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-const { generateRandomUserID, findUserByEmail, addDataToCurrentUser, findStepGoalAverage, getHydrationFor7Days, calculateTotalHydration, findDistanceTraveled, ouncesPerDay, calculateAverageHoursSlept, calculateAverageSleepQuality, hoursSleptGivenDate, sleepQualityGivenDate, getSleepFor7Days, getSleepQualityFor7Days, checkStepGoal, minutesActiveGivenDate, checkStepGoal7Days, numberOfStepsGivenDate, findBottomDrinkers } = require('../src/scriptDefinitions');
+const { generateRandomUserID, findUserByEmail, addDataToCurrentUser, findStepGoalAverage, getHydrationFor7Days, calculateTotalHydration, findDistanceTraveled, ouncesPerDay, calculateAverageHoursSlept, calculateAverageSleepQuality, hoursSleptGivenDate, sleepQualityGivenDate, getSleepFor7Days, getSleepQualityFor7Days, checkStepGoal, minutesActiveGivenDate, checkStepGoal7Days, numberOfStepsGivenDate, findBottomDrinkers, findBottomSleepers } = require('../src/scriptDefinitions');
 const { users, hydrationData, activityData, sleepData } = require('../src/data/testData');
 
 describe('userObject creation', function () {
@@ -109,266 +109,289 @@ describe('bottom 10s', function () {
       }
     ]);
   });
+
+  it('should return userID, totalHoursSlept, averageHoursSlept, and username for the (up to) 10 worst sleepers', function () {
+    expect(findBottomSleepers(sleepData, users)).to.deep.equal([
+      {
+        userID: 3,
+        totalHoursSlept: 0,
+        averageHoursSlept: NaN,
+        userName: 'Colt Rohan'
+      },
+      {
+        userID: 1,
+        totalHoursSlept: 9.6,
+        averageHoursSlept: 9.6,
+        userName: 'Trystan Gorczany'
+      },
+      {
+        userID: 2,
+        totalHoursSlept: 56.5,
+        averageHoursSlept: 8.071428571428571,
+        userName: 'Tyreek VonRueden'
+      }
+    ]);
+  });
 });
 
 describe('tests that require complete current users with varying data', function () {
-    const currentUser1 = addDataToCurrentUser(users[0], hydrationData, activityData, sleepData);
-    const currentUser2 = addDataToCurrentUser(users[1], hydrationData, activityData, sleepData);
-    const currentUser3 = addDataToCurrentUser(users[2], hydrationData, activityData, sleepData);
+  const currentUser1 = addDataToCurrentUser(users[0], hydrationData, activityData, sleepData);
+  const currentUser2 = addDataToCurrentUser(users[1], hydrationData, activityData, sleepData);
+  const currentUser3 = addDataToCurrentUser(users[2], hydrationData, activityData, sleepData);
 
-    describe('ouncesPerDay', function () {
-      it('should return numOunces when the date is found', function () {
-        expect(ouncesPerDay(currentUser2, '2023/03/24')).to.deep.equal(35);
-      });
-
-      it('should return undefined when the date is not found', function () {
-        expect(ouncesPerDay(currentUser2, '2023/03/31')).to.be.undefined;
-      });
-
-      it('should return undefined when the hydrationData array is empty', function () {
-        expect(ouncesPerDay(currentUser3, '2023/03/24')).to.be.undefined;
-      });
+  describe('ouncesPerDay', function () {
+    it('should return numOunces when the date is found', function () {
+      expect(ouncesPerDay(currentUser2, '2023/03/24')).to.deep.equal(35);
     });
 
-    describe('getHydrationFor7Days', function () {
-      it('should return hydration data for 7 days when data for all 7 days is available', function () {
-        const sevenDayHydration = getHydrationFor7Days(currentUser2, '2023/03/30');
-
-        expect(sevenDayHydration.length).to.deep.equal(7);
-        expect(sevenDayHydration).to.deep.equal([
-          { date: '2023/03/24', numOunces: 35 },
-          { date: '2023/03/25', numOunces: 92 },
-          { date: '2023/03/26', numOunces: 88 },
-          { date: '2023/03/27', numOunces: 88 },
-          { date: '2023/03/28', numOunces: 68 },
-          { date: '2023/03/29', numOunces: 50 },
-          { date: '2023/03/30', numOunces: 57 }
-        ]);
-      });
-
-      it('should return an empty array when no matching hydration data is found', function () {
-        const sevenDayHydration = getHydrationFor7Days(currentUser3, '2023/03/30');
-
-        expect(sevenDayHydration.length).to.deep.equal(0);
-        expect(sevenDayHydration).to.deep.equal([]);
-      });
-
-      it('should return partial data when only some of the 7 days have hydration data', function () {
-        const sevenDayHydration = getHydrationFor7Days(currentUser1, '2023/03/30');
-
-        expect(sevenDayHydration.length).to.deep.equal(1);
-        expect(sevenDayHydration).to.deep.equal([{ date: '2023/03/24', numOunces: 28 }]);
-      });
+    it('should return undefined when the date is not found', function () {
+      expect(ouncesPerDay(currentUser2, '2023/03/31')).to.be.undefined;
     });
 
-    describe('calculateTotalHydration', function () {
-      it('should return 0 when there is no hydration data', function () {
-        expect(calculateTotalHydration(currentUser3)).to.deep.equal('0.00');
-      });
-
-      it('should return the average hydration when there is one hydration data entry', function () {
-        expect(calculateTotalHydration(currentUser1)).to.deep.equal('28.00');
-      });
-
-      it('should return the average hydration when there are multiple hydration data entries', function () {
-        expect(calculateTotalHydration(currentUser2)).to.deep.equal('68.29');
-      });
-    });
-
-    describe('distance traveled', function () {
-      it('should return the distance traveled by a user on the most recent day', function () {
-        expect(findDistanceTraveled(currentUser1)).to.deep.equal('5.58');
-        expect(findDistanceTraveled(currentUser2)).to.deep.equal('3.99');
-      });
-    });
-
-    describe('calculateAverageHoursSlept', function () {
-      it('should return 0 when there is no sleep data', function () {
-        expect(calculateTotalHydration(currentUser3)).to.deep.equal('0.00');
-      });
-
-      it('should return the average hours slept when there is one sleep data entry', function () {
-        expect(calculateAverageHoursSlept(currentUser1)).to.deep.equal('9.60');
-      });
-
-      it('should return the average hours slept when there are multiple sleep data entries', function () {
-        expect(calculateAverageHoursSlept(currentUser2)).to.deep.equal('8.07');
-      });
-    });
-
-    describe('calculateAverageSleepQuality', function () {
-      it('should return 0 when there is no sleep data', function () {
-        expect(calculateAverageSleepQuality(currentUser3)).to.deep.equal('0.00');
-      });
-
-      it('should return the average sleep quality when there is one sleep data entry', function () {
-        expect(calculateAverageSleepQuality(currentUser1)).to.deep.equal('4.30');
-      });
-
-      it('should return the average sleep quality when there are multiple sleep data entries', function () {
-        expect(calculateAverageSleepQuality(currentUser2)).to.deep.equal('3.33');
-      });
-    });
-
-    describe('hoursSleptGivenDate', function () {
-      it('should return hoursSlept when the date is found', function () {
-        expect(hoursSleptGivenDate(currentUser1, '2023/03/24')).to.deep.equal(9.60);
-      });
-
-      it('should return undefined when the date is not found', function () {
-        expect(hoursSleptGivenDate(currentUser1, '2023/03/25')).to.be.undefined;
-      });
-
-      it('should return undefined when the sleepData array is empty', function () {
-        expect(hoursSleptGivenDate(currentUser3, '2023/03/25')).to.be.undefined;
-      });
-    });
-
-    describe('sleepQualityGivenDate', function () {
-      it('should return sleepQuality when the date is found', function () {
-        expect(sleepQualityGivenDate(currentUser1, '2023/03/24')).to.deep.equal(4.30);
-      });
-
-      it('should return undefined when the date is not found', function () {
-        expect(sleepQualityGivenDate(currentUser1, '2023/03/25')).to.be.undefined;
-      });
-
-      it('should return undefined when the sleepData array is empty', function () {
-        expect(sleepQualityGivenDate(currentUser3, '2023/03/25')).to.be.undefined;
-      });
-    });
-
-    describe('getSleepQualityFor7Days', function () {
-      it('should return sleep quality data for 7 days when data is available', function () {
-        const sevenDaySleepQuality = getSleepQualityFor7Days(currentUser2, '2023/03/30');
-
-        expect(sevenDaySleepQuality.length).to.deep.equal(7);
-        expect(sevenDaySleepQuality).to.deep.equal([
-          { date: '2023/03/24', sleepQuality: 3.5 },
-          { date: '2023/03/25', sleepQuality: 4.7 },
-          { date: '2023/03/26', sleepQuality: 4.8 },
-          { date: '2023/03/27', sleepQuality: 2.8 },
-          { date: '2023/03/28', sleepQuality: 2.1 },
-          { date: '2023/03/29', sleepQuality: 2.2 },
-          { date: '2023/03/30', sleepQuality: 3.2 }
-        ]);
-      });
-
-      it('should return an empty array when no matching data is found', function () {
-        const sevenDaySleepQuality = getSleepQualityFor7Days(currentUser3, '2023/03/30');
-
-        expect(sevenDaySleepQuality.length).to.deep.equal(0);
-        expect(sevenDaySleepQuality).to.deep.equal([]);
-      });
-
-      it('should return partial data when only some days have sleep data', function () {
-        const sevenDaySleepQuality = getSleepQualityFor7Days(currentUser1, '2023/03/30');
-
-        expect(sevenDaySleepQuality.length).to.deep.equal(1);
-        expect(sevenDaySleepQuality).to.deep.equal([{ date: '2023/03/24', sleepQuality: 4.3 }]);
-      });
-    });
-
-    describe('getSleepFor7Days', function () {
-      it('should return sleep hours data for 7 days when data is available', function () {
-        const sevenDaySleep = getSleepFor7Days(currentUser2, '2023/03/30');
-
-        expect(sevenDaySleep).to.be.an('array');
-        expect(sevenDaySleep.length).to.deep.equal(7);
-        expect(sevenDaySleep).to.deep.equal([
-          { date: '2023/03/24', hoursSlept: 8.4 },
-          { date: '2023/03/25', hoursSlept: 8.1 },
-          { date: '2023/03/26', hoursSlept: 9.8 },
-          { date: '2023/03/27', hoursSlept: 10.7 },
-          { date: '2023/03/28', hoursSlept: 5.1 },
-          { date: '2023/03/29', hoursSlept: 4.3 },
-          { date: '2023/03/30', hoursSlept: 10.1 }
-        ]);
-      });
-
-      it('should return an empty array when no matching data is found', function () {
-        const sevenDaySleep = getSleepFor7Days(currentUser3, '2023/03/30');
-
-        expect(sevenDaySleep.length).to.deep.equal(0);
-        expect(sevenDaySleep).to.deep.equal([]);
-      });
-
-      it('should return partial data when only some days have sleep data', function () {
-        const sevenDaySleep = getSleepFor7Days(currentUser1, '2023/03/30');
-
-        expect(sevenDaySleep.length).to.deep.equal(1);
-        expect(sevenDaySleep).to.deep.equal([{ date: '2023/03/24', hoursSlept: 9.6 }]);
-      });
-    });
-
-    describe('checkStepGoal', function () {
-      it('should return "Success!" when the latest numSteps is greater than or equal to dailyStepGoal', function () {
-        expect(checkStepGoal(currentUser1)).to.deep.equal('Success!');
-      });
-
-      it('should return "No!" when the latest numSteps is less than dailyStepGoal', function () {
-        expect(checkStepGoal(currentUser2)).to.deep.equal('No!');
-      });
-
-      it('should handle cases where activityData is empty, returning "No!"', function () {
-        expect(checkStepGoal(currentUser3)).to.deep.equal('No!');
-      });
-    });
-
-    describe('minutesActiveGivenDate', function () {
-      it('should return minutes active when the date is found', function () {
-        expect(minutesActiveGivenDate(currentUser1, '2023/03/24')).to.deep.equal(261);
-      });
-
-      it('should return undefined when the date is not found', function () {
-        expect(minutesActiveGivenDate(currentUser1, '2023/03/25')).to.be.undefined;
-      });
-
-      it('should return undefined when the activityData array is empty', function () {
-        expect(minutesActiveGivenDate(currentUser3, '2023/03/25')).to.be.undefined;
-      });
-    });
-
-    describe('numberOfStepsGivenDate', function () {
-      it('should return the number of steps when the date is found', function () {
-        expect(numberOfStepsGivenDate(currentUser2, '2023/03/28')).to.equal(5494);
-        expect(numberOfStepsGivenDate(currentUser2, '2023/03/29')).to.equal(6959);
-        expect(numberOfStepsGivenDate(currentUser2, '2023/03/30')).to.equal(4676);
-      });
-
-      it('should return undefined when the date is not found', function () {
-        expect(numberOfStepsGivenDate(currentUser1, '2023/03/28')).to.be.undefined;
-        expect(numberOfStepsGivenDate(currentUser1, '2023/03/29')).to.be.undefined;
-        expect(numberOfStepsGivenDate(currentUser1, '2023/03/30')).to.be.undefined;
-      });
-
-      it('should return undefined when the activityData array is empty', function () {
-        expect(numberOfStepsGivenDate(currentUser3, '2023/03/28')).to.be.undefined;
-        expect(numberOfStepsGivenDate(currentUser3, '2023/03/29')).to.be.undefined;
-        expect(numberOfStepsGivenDate(currentUser3, '2023/03/30')).to.be.undefined;
-      });
-    });
-
-    describe('checkStepGoal7Days', function () {
-
-      it('should return an array of objects containing date, numSteps, and metGoal properties', function () {
-        expect(checkStepGoal7Days(currentUser2)[0]).to.have.all.keys('date', 'numSteps', 'metGoal');
-      });
-
-      it('should return the correct metGoal values based on numSteps and dailyStepGoal for all 7 days', function () {
-        expect(checkStepGoal7Days(currentUser2)).to.deep.equal([
-          { date: '2023/03/30', numSteps: 4676, metGoal: 'Keep trying!' },
-          { date: '2023/03/29', numSteps: 6959, metGoal: 'Keep trying!' },
-          { date: '2023/03/28', numSteps: 5494, metGoal: 'Keep trying!' },
-          { date: '2023/03/27', numSteps: 12127, metGoal: 'You did it!' },
-          { date: '2023/03/26', numSteps: 9543, metGoal: 'You did it!' },
-          { date: '2023/03/25', numSteps: 14719, metGoal: 'You did it!' },
-          { date: '2023/03/24', numSteps: 3049, metGoal: 'Keep trying!' },
-        ]);
-      });
-
-      it('should handle users with no activityData, returning "No activity data available!"', function () {
-        expect(checkStepGoal7Days(currentUser3)).to.equal('No activity data available!');
-      });
+    it('should return undefined when the hydrationData array is empty', function () {
+      expect(ouncesPerDay(currentUser3, '2023/03/24')).to.be.undefined;
     });
   });
+
+  describe('getHydrationFor7Days', function () {
+    it('should return hydration data for 7 days when data for all 7 days is available', function () {
+      const sevenDayHydration = getHydrationFor7Days(currentUser2, '2023/03/30');
+
+      expect(sevenDayHydration.length).to.deep.equal(7);
+      expect(sevenDayHydration).to.deep.equal([
+        { date: '2023/03/24', numOunces: 35 },
+        { date: '2023/03/25', numOunces: 92 },
+        { date: '2023/03/26', numOunces: 88 },
+        { date: '2023/03/27', numOunces: 88 },
+        { date: '2023/03/28', numOunces: 68 },
+        { date: '2023/03/29', numOunces: 50 },
+        { date: '2023/03/30', numOunces: 57 }
+      ]);
+    });
+
+    it('should return an empty array when no matching hydration data is found', function () {
+      const sevenDayHydration = getHydrationFor7Days(currentUser3, '2023/03/30');
+
+      expect(sevenDayHydration.length).to.deep.equal(0);
+      expect(sevenDayHydration).to.deep.equal([]);
+    });
+
+    it('should return partial data when only some of the 7 days have hydration data', function () {
+      const sevenDayHydration = getHydrationFor7Days(currentUser1, '2023/03/30');
+
+      expect(sevenDayHydration.length).to.deep.equal(1);
+      expect(sevenDayHydration).to.deep.equal([{ date: '2023/03/24', numOunces: 28 }]);
+    });
+  });
+
+  describe('calculateTotalHydration', function () {
+    it('should return 0 when there is no hydration data', function () {
+      expect(calculateTotalHydration(currentUser3)).to.deep.equal('0.00');
+    });
+
+    it('should return the average hydration when there is one hydration data entry', function () {
+      expect(calculateTotalHydration(currentUser1)).to.deep.equal('28.00');
+    });
+
+    it('should return the average hydration when there are multiple hydration data entries', function () {
+      expect(calculateTotalHydration(currentUser2)).to.deep.equal('68.29');
+    });
+  });
+
+  describe('distance traveled', function () {
+    it('should return the distance traveled by a user on the most recent day', function () {
+      expect(findDistanceTraveled(currentUser1)).to.deep.equal('5.58');
+      expect(findDistanceTraveled(currentUser2)).to.deep.equal('3.99');
+    });
+  });
+
+  describe('calculateAverageHoursSlept', function () {
+    it('should return 0 when there is no sleep data', function () {
+      expect(calculateTotalHydration(currentUser3)).to.deep.equal('0.00');
+    });
+
+    it('should return the average hours slept when there is one sleep data entry', function () {
+      expect(calculateAverageHoursSlept(currentUser1)).to.deep.equal('9.60');
+    });
+
+    it('should return the average hours slept when there are multiple sleep data entries', function () {
+      expect(calculateAverageHoursSlept(currentUser2)).to.deep.equal('8.07');
+    });
+  });
+
+  describe('calculateAverageSleepQuality', function () {
+    it('should return 0 when there is no sleep data', function () {
+      expect(calculateAverageSleepQuality(currentUser3)).to.deep.equal('0.00');
+    });
+
+    it('should return the average sleep quality when there is one sleep data entry', function () {
+      expect(calculateAverageSleepQuality(currentUser1)).to.deep.equal('4.30');
+    });
+
+    it('should return the average sleep quality when there are multiple sleep data entries', function () {
+      expect(calculateAverageSleepQuality(currentUser2)).to.deep.equal('3.33');
+    });
+  });
+
+  describe('hoursSleptGivenDate', function () {
+    it('should return hoursSlept when the date is found', function () {
+      expect(hoursSleptGivenDate(currentUser1, '2023/03/24')).to.deep.equal(9.60);
+    });
+
+    it('should return undefined when the date is not found', function () {
+      expect(hoursSleptGivenDate(currentUser1, '2023/03/25')).to.be.undefined;
+    });
+
+    it('should return undefined when the sleepData array is empty', function () {
+      expect(hoursSleptGivenDate(currentUser3, '2023/03/25')).to.be.undefined;
+    });
+  });
+
+  describe('sleepQualityGivenDate', function () {
+    it('should return sleepQuality when the date is found', function () {
+      expect(sleepQualityGivenDate(currentUser1, '2023/03/24')).to.deep.equal(4.30);
+    });
+
+    it('should return undefined when the date is not found', function () {
+      expect(sleepQualityGivenDate(currentUser1, '2023/03/25')).to.be.undefined;
+    });
+
+    it('should return undefined when the sleepData array is empty', function () {
+      expect(sleepQualityGivenDate(currentUser3, '2023/03/25')).to.be.undefined;
+    });
+  });
+
+  describe('getSleepQualityFor7Days', function () {
+    it('should return sleep quality data for 7 days when data is available', function () {
+      const sevenDaySleepQuality = getSleepQualityFor7Days(currentUser2, '2023/03/30');
+
+      expect(sevenDaySleepQuality.length).to.deep.equal(7);
+      expect(sevenDaySleepQuality).to.deep.equal([
+        { date: '2023/03/24', sleepQuality: 3.5 },
+        { date: '2023/03/25', sleepQuality: 4.7 },
+        { date: '2023/03/26', sleepQuality: 4.8 },
+        { date: '2023/03/27', sleepQuality: 2.8 },
+        { date: '2023/03/28', sleepQuality: 2.1 },
+        { date: '2023/03/29', sleepQuality: 2.2 },
+        { date: '2023/03/30', sleepQuality: 3.2 }
+      ]);
+    });
+
+    it('should return an empty array when no matching data is found', function () {
+      const sevenDaySleepQuality = getSleepQualityFor7Days(currentUser3, '2023/03/30');
+
+      expect(sevenDaySleepQuality.length).to.deep.equal(0);
+      expect(sevenDaySleepQuality).to.deep.equal([]);
+    });
+
+    it('should return partial data when only some days have sleep data', function () {
+      const sevenDaySleepQuality = getSleepQualityFor7Days(currentUser1, '2023/03/30');
+
+      expect(sevenDaySleepQuality.length).to.deep.equal(1);
+      expect(sevenDaySleepQuality).to.deep.equal([{ date: '2023/03/24', sleepQuality: 4.3 }]);
+    });
+  });
+
+  describe('getSleepFor7Days', function () {
+    it('should return sleep hours data for 7 days when data is available', function () {
+      const sevenDaySleep = getSleepFor7Days(currentUser2, '2023/03/30');
+
+      expect(sevenDaySleep).to.be.an('array');
+      expect(sevenDaySleep.length).to.deep.equal(7);
+      expect(sevenDaySleep).to.deep.equal([
+        { date: '2023/03/24', hoursSlept: 8.4 },
+        { date: '2023/03/25', hoursSlept: 8.1 },
+        { date: '2023/03/26', hoursSlept: 9.8 },
+        { date: '2023/03/27', hoursSlept: 10.7 },
+        { date: '2023/03/28', hoursSlept: 5.1 },
+        { date: '2023/03/29', hoursSlept: 4.3 },
+        { date: '2023/03/30', hoursSlept: 10.1 }
+      ]);
+    });
+
+    it('should return an empty array when no matching data is found', function () {
+      const sevenDaySleep = getSleepFor7Days(currentUser3, '2023/03/30');
+
+      expect(sevenDaySleep.length).to.deep.equal(0);
+      expect(sevenDaySleep).to.deep.equal([]);
+    });
+
+    it('should return partial data when only some days have sleep data', function () {
+      const sevenDaySleep = getSleepFor7Days(currentUser1, '2023/03/30');
+
+      expect(sevenDaySleep.length).to.deep.equal(1);
+      expect(sevenDaySleep).to.deep.equal([{ date: '2023/03/24', hoursSlept: 9.6 }]);
+    });
+  });
+
+  describe('checkStepGoal', function () {
+    it('should return "Success!" when the latest numSteps is greater than or equal to dailyStepGoal', function () {
+      expect(checkStepGoal(currentUser1)).to.deep.equal('Success!');
+    });
+
+    it('should return "No!" when the latest numSteps is less than dailyStepGoal', function () {
+      expect(checkStepGoal(currentUser2)).to.deep.equal('No!');
+    });
+
+    it('should handle cases where activityData is empty, returning "No!"', function () {
+      expect(checkStepGoal(currentUser3)).to.deep.equal('No!');
+    });
+  });
+
+  describe('minutesActiveGivenDate', function () {
+    it('should return minutes active when the date is found', function () {
+      expect(minutesActiveGivenDate(currentUser1, '2023/03/24')).to.deep.equal(261);
+    });
+
+    it('should return undefined when the date is not found', function () {
+      expect(minutesActiveGivenDate(currentUser1, '2023/03/25')).to.be.undefined;
+    });
+
+    it('should return undefined when the activityData array is empty', function () {
+      expect(minutesActiveGivenDate(currentUser3, '2023/03/25')).to.be.undefined;
+    });
+  });
+
+  describe('numberOfStepsGivenDate', function () {
+    it('should return the number of steps when the date is found', function () {
+      expect(numberOfStepsGivenDate(currentUser2, '2023/03/28')).to.equal(5494);
+      expect(numberOfStepsGivenDate(currentUser2, '2023/03/29')).to.equal(6959);
+      expect(numberOfStepsGivenDate(currentUser2, '2023/03/30')).to.equal(4676);
+    });
+
+    it('should return undefined when the date is not found', function () {
+      expect(numberOfStepsGivenDate(currentUser1, '2023/03/28')).to.be.undefined;
+      expect(numberOfStepsGivenDate(currentUser1, '2023/03/29')).to.be.undefined;
+      expect(numberOfStepsGivenDate(currentUser1, '2023/03/30')).to.be.undefined;
+    });
+
+    it('should return undefined when the activityData array is empty', function () {
+      expect(numberOfStepsGivenDate(currentUser3, '2023/03/28')).to.be.undefined;
+      expect(numberOfStepsGivenDate(currentUser3, '2023/03/29')).to.be.undefined;
+      expect(numberOfStepsGivenDate(currentUser3, '2023/03/30')).to.be.undefined;
+    });
+  });
+
+  describe('checkStepGoal7Days', function () {
+
+    it('should return an array of objects containing date, numSteps, and metGoal properties', function () {
+      expect(checkStepGoal7Days(currentUser2)[0]).to.have.all.keys('date', 'numSteps', 'metGoal');
+    });
+
+    it('should return the correct metGoal values based on numSteps and dailyStepGoal for all 7 days', function () {
+      expect(checkStepGoal7Days(currentUser2)).to.deep.equal([
+        { date: '2023/03/30', numSteps: 4676, metGoal: 'Keep trying!' },
+        { date: '2023/03/29', numSteps: 6959, metGoal: 'Keep trying!' },
+        { date: '2023/03/28', numSteps: 5494, metGoal: 'Keep trying!' },
+        { date: '2023/03/27', numSteps: 12127, metGoal: 'You did it!' },
+        { date: '2023/03/26', numSteps: 9543, metGoal: 'You did it!' },
+        { date: '2023/03/25', numSteps: 14719, metGoal: 'You did it!' },
+        { date: '2023/03/24', numSteps: 3049, metGoal: 'Keep trying!' },
+      ]);
+    });
+
+    it('should handle users with no activityData, returning "No activity data available!"', function () {
+      expect(checkStepGoal7Days(currentUser3)).to.equal('No activity data available!');
+    });
+  });
+});

--- a/test/scripts-test.js
+++ b/test/scripts-test.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-const { generateRandomUserID, findUserByEmail, addDataToCurrentUser, findStepGoalAverage, getHydrationFor7Days, calculateTotalHydration, findDistanceTraveled, ouncesPerDay, calculateAverageHoursSlept, calculateAverageSleepQuality, hoursSleptGivenDate, sleepQualityGivenDate, getSleepFor7Days, getSleepQualityFor7Days, checkStepGoal, minutesActiveGivenDate, checkStepGoal7Days, numberOfStepsGivenDate, findBottomDrinkers, findBottomSleepers } = require('../src/scriptDefinitions');
+const { generateRandomUserID, findUserByEmail, addDataToCurrentUser, findStepGoalAverage, getHydrationFor7Days, calculateTotalHydration, findDistanceTraveled, ouncesPerDay, calculateAverageHoursSlept, calculateAverageSleepQuality, hoursSleptGivenDate, sleepQualityGivenDate, getSleepFor7Days, getSleepQualityFor7Days, checkStepGoal, minutesActiveGivenDate, checkStepGoal7Days, numberOfStepsGivenDate, findBottomDrinkers, findBottomSleepers, findBottomStepTakers } = require('../src/scriptDefinitions');
 const { users, hydrationData, activityData, sleepData } = require('../src/data/testData');
 
 describe('userObject creation', function () {
@@ -128,6 +128,29 @@ describe('bottom 10s', function () {
         userID: 2,
         totalHoursSlept: 56.5,
         averageHoursSlept: 8.071428571428571,
+        userName: 'Tyreek VonRueden'
+      }
+    ]);
+  });
+
+  it('should return userID, totalSteps, averageSteps, and userName for the (up to) 10 worst steppers', function () {
+    expect(findBottomStepTakers(activityData, users)).to.deep.equal([
+      {
+        userID: 3,
+        totalSteps: 0,
+        averageSteps: NaN,
+        userName: 'Colt Rohan'
+      },
+      {
+        userID: 1,
+        totalSteps: 7362,
+        averageSteps: 7362,
+        userName: 'Trystan Gorczany'
+      },
+      {
+        userID: 2,
+        totalSteps: 56567,
+        averageSteps: 8081,
         userName: 'Tyreek VonRueden'
       }
     ]);

--- a/test/scripts-test.js
+++ b/test/scripts-test.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-const { generateRandomUserID, findUserByEmail, addDataToCurrentUser, findStepGoalAverage, getHydrationFor7Days, calculateTotalHydration, findDistanceTraveled, ouncesPerDay, calculateAverageHoursSlept, calculateAverageSleepQuality, hoursSleptGivenDate, sleepQualityGivenDate, getSleepFor7Days, getSleepQualityFor7Days, checkStepGoal, minutesActiveGivenDate, checkStepGoal7Days, numberOfStepsGivenDate } = require('../src/scriptDefinitions');
+const { generateRandomUserID, findUserByEmail, addDataToCurrentUser, findStepGoalAverage, getHydrationFor7Days, calculateTotalHydration, findDistanceTraveled, ouncesPerDay, calculateAverageHoursSlept, calculateAverageSleepQuality, hoursSleptGivenDate, sleepQualityGivenDate, getSleepFor7Days, getSleepQualityFor7Days, checkStepGoal, minutesActiveGivenDate, checkStepGoal7Days, numberOfStepsGivenDate, findBottomDrinkers } = require('../src/scriptDefinitions');
 const { users, hydrationData, activityData, sleepData } = require('../src/data/testData');
 
 describe('userObject creation', function () {
@@ -86,264 +86,289 @@ describe('global average step goal', function () {
   });
 });
 
+describe('bottom 10s', function () {
+  it('should return userID, totalOunces, averageOunces, and userName for the (up to) 10 worst drinkers', function () {
+    expect(findBottomDrinkers(hydrationData, users)).to.deep.equal([
+      {
+        userID: 3,
+        totalOunces: 0,
+        averageOunces: NaN,
+        userName: 'Colt Rohan'
+      },
+      {
+        userID: 1,
+        totalOunces: 28,
+        averageOunces: 28,
+        userName: 'Trystan Gorczany'
+      },
+      {
+        userID: 2,
+        totalOunces: 478,
+        averageOunces: 68.28571428571429,
+        userName: 'Tyreek VonRueden'
+      }
+    ]);
+  });
+});
+
 describe('tests that require complete current users with varying data', function () {
-  const currentUser1 = addDataToCurrentUser(users[0], hydrationData, activityData, sleepData);
-  const currentUser2 = addDataToCurrentUser(users[1], hydrationData, activityData, sleepData);
-  const currentUser3 = addDataToCurrentUser(users[2], hydrationData, activityData, sleepData);
+    const currentUser1 = addDataToCurrentUser(users[0], hydrationData, activityData, sleepData);
+    const currentUser2 = addDataToCurrentUser(users[1], hydrationData, activityData, sleepData);
+    const currentUser3 = addDataToCurrentUser(users[2], hydrationData, activityData, sleepData);
 
-  describe('ouncesPerDay', function () {
-    it('should return numOunces when the date is found', function () {
-      expect(ouncesPerDay(currentUser2, '2023/03/24')).to.deep.equal(35);
+    describe('ouncesPerDay', function () {
+      it('should return numOunces when the date is found', function () {
+        expect(ouncesPerDay(currentUser2, '2023/03/24')).to.deep.equal(35);
+      });
+
+      it('should return undefined when the date is not found', function () {
+        expect(ouncesPerDay(currentUser2, '2023/03/31')).to.be.undefined;
+      });
+
+      it('should return undefined when the hydrationData array is empty', function () {
+        expect(ouncesPerDay(currentUser3, '2023/03/24')).to.be.undefined;
+      });
     });
 
-    it('should return undefined when the date is not found', function () {
-      expect(ouncesPerDay(currentUser2, '2023/03/31')).to.be.undefined;
+    describe('getHydrationFor7Days', function () {
+      it('should return hydration data for 7 days when data for all 7 days is available', function () {
+        const sevenDayHydration = getHydrationFor7Days(currentUser2, '2023/03/30');
+
+        expect(sevenDayHydration.length).to.deep.equal(7);
+        expect(sevenDayHydration).to.deep.equal([
+          { date: '2023/03/24', numOunces: 35 },
+          { date: '2023/03/25', numOunces: 92 },
+          { date: '2023/03/26', numOunces: 88 },
+          { date: '2023/03/27', numOunces: 88 },
+          { date: '2023/03/28', numOunces: 68 },
+          { date: '2023/03/29', numOunces: 50 },
+          { date: '2023/03/30', numOunces: 57 }
+        ]);
+      });
+
+      it('should return an empty array when no matching hydration data is found', function () {
+        const sevenDayHydration = getHydrationFor7Days(currentUser3, '2023/03/30');
+
+        expect(sevenDayHydration.length).to.deep.equal(0);
+        expect(sevenDayHydration).to.deep.equal([]);
+      });
+
+      it('should return partial data when only some of the 7 days have hydration data', function () {
+        const sevenDayHydration = getHydrationFor7Days(currentUser1, '2023/03/30');
+
+        expect(sevenDayHydration.length).to.deep.equal(1);
+        expect(sevenDayHydration).to.deep.equal([{ date: '2023/03/24', numOunces: 28 }]);
+      });
     });
 
-    it('should return undefined when the hydrationData array is empty', function () {
-      expect(ouncesPerDay(currentUser3, '2023/03/24')).to.be.undefined;
+    describe('calculateTotalHydration', function () {
+      it('should return 0 when there is no hydration data', function () {
+        expect(calculateTotalHydration(currentUser3)).to.deep.equal('0.00');
+      });
+
+      it('should return the average hydration when there is one hydration data entry', function () {
+        expect(calculateTotalHydration(currentUser1)).to.deep.equal('28.00');
+      });
+
+      it('should return the average hydration when there are multiple hydration data entries', function () {
+        expect(calculateTotalHydration(currentUser2)).to.deep.equal('68.29');
+      });
+    });
+
+    describe('distance traveled', function () {
+      it('should return the distance traveled by a user on the most recent day', function () {
+        expect(findDistanceTraveled(currentUser1)).to.deep.equal('5.58');
+        expect(findDistanceTraveled(currentUser2)).to.deep.equal('3.99');
+      });
+    });
+
+    describe('calculateAverageHoursSlept', function () {
+      it('should return 0 when there is no sleep data', function () {
+        expect(calculateTotalHydration(currentUser3)).to.deep.equal('0.00');
+      });
+
+      it('should return the average hours slept when there is one sleep data entry', function () {
+        expect(calculateAverageHoursSlept(currentUser1)).to.deep.equal('9.60');
+      });
+
+      it('should return the average hours slept when there are multiple sleep data entries', function () {
+        expect(calculateAverageHoursSlept(currentUser2)).to.deep.equal('8.07');
+      });
+    });
+
+    describe('calculateAverageSleepQuality', function () {
+      it('should return 0 when there is no sleep data', function () {
+        expect(calculateAverageSleepQuality(currentUser3)).to.deep.equal('0.00');
+      });
+
+      it('should return the average sleep quality when there is one sleep data entry', function () {
+        expect(calculateAverageSleepQuality(currentUser1)).to.deep.equal('4.30');
+      });
+
+      it('should return the average sleep quality when there are multiple sleep data entries', function () {
+        expect(calculateAverageSleepQuality(currentUser2)).to.deep.equal('3.33');
+      });
+    });
+
+    describe('hoursSleptGivenDate', function () {
+      it('should return hoursSlept when the date is found', function () {
+        expect(hoursSleptGivenDate(currentUser1, '2023/03/24')).to.deep.equal(9.60);
+      });
+
+      it('should return undefined when the date is not found', function () {
+        expect(hoursSleptGivenDate(currentUser1, '2023/03/25')).to.be.undefined;
+      });
+
+      it('should return undefined when the sleepData array is empty', function () {
+        expect(hoursSleptGivenDate(currentUser3, '2023/03/25')).to.be.undefined;
+      });
+    });
+
+    describe('sleepQualityGivenDate', function () {
+      it('should return sleepQuality when the date is found', function () {
+        expect(sleepQualityGivenDate(currentUser1, '2023/03/24')).to.deep.equal(4.30);
+      });
+
+      it('should return undefined when the date is not found', function () {
+        expect(sleepQualityGivenDate(currentUser1, '2023/03/25')).to.be.undefined;
+      });
+
+      it('should return undefined when the sleepData array is empty', function () {
+        expect(sleepQualityGivenDate(currentUser3, '2023/03/25')).to.be.undefined;
+      });
+    });
+
+    describe('getSleepQualityFor7Days', function () {
+      it('should return sleep quality data for 7 days when data is available', function () {
+        const sevenDaySleepQuality = getSleepQualityFor7Days(currentUser2, '2023/03/30');
+
+        expect(sevenDaySleepQuality.length).to.deep.equal(7);
+        expect(sevenDaySleepQuality).to.deep.equal([
+          { date: '2023/03/24', sleepQuality: 3.5 },
+          { date: '2023/03/25', sleepQuality: 4.7 },
+          { date: '2023/03/26', sleepQuality: 4.8 },
+          { date: '2023/03/27', sleepQuality: 2.8 },
+          { date: '2023/03/28', sleepQuality: 2.1 },
+          { date: '2023/03/29', sleepQuality: 2.2 },
+          { date: '2023/03/30', sleepQuality: 3.2 }
+        ]);
+      });
+
+      it('should return an empty array when no matching data is found', function () {
+        const sevenDaySleepQuality = getSleepQualityFor7Days(currentUser3, '2023/03/30');
+
+        expect(sevenDaySleepQuality.length).to.deep.equal(0);
+        expect(sevenDaySleepQuality).to.deep.equal([]);
+      });
+
+      it('should return partial data when only some days have sleep data', function () {
+        const sevenDaySleepQuality = getSleepQualityFor7Days(currentUser1, '2023/03/30');
+
+        expect(sevenDaySleepQuality.length).to.deep.equal(1);
+        expect(sevenDaySleepQuality).to.deep.equal([{ date: '2023/03/24', sleepQuality: 4.3 }]);
+      });
+    });
+
+    describe('getSleepFor7Days', function () {
+      it('should return sleep hours data for 7 days when data is available', function () {
+        const sevenDaySleep = getSleepFor7Days(currentUser2, '2023/03/30');
+
+        expect(sevenDaySleep).to.be.an('array');
+        expect(sevenDaySleep.length).to.deep.equal(7);
+        expect(sevenDaySleep).to.deep.equal([
+          { date: '2023/03/24', hoursSlept: 8.4 },
+          { date: '2023/03/25', hoursSlept: 8.1 },
+          { date: '2023/03/26', hoursSlept: 9.8 },
+          { date: '2023/03/27', hoursSlept: 10.7 },
+          { date: '2023/03/28', hoursSlept: 5.1 },
+          { date: '2023/03/29', hoursSlept: 4.3 },
+          { date: '2023/03/30', hoursSlept: 10.1 }
+        ]);
+      });
+
+      it('should return an empty array when no matching data is found', function () {
+        const sevenDaySleep = getSleepFor7Days(currentUser3, '2023/03/30');
+
+        expect(sevenDaySleep.length).to.deep.equal(0);
+        expect(sevenDaySleep).to.deep.equal([]);
+      });
+
+      it('should return partial data when only some days have sleep data', function () {
+        const sevenDaySleep = getSleepFor7Days(currentUser1, '2023/03/30');
+
+        expect(sevenDaySleep.length).to.deep.equal(1);
+        expect(sevenDaySleep).to.deep.equal([{ date: '2023/03/24', hoursSlept: 9.6 }]);
+      });
+    });
+
+    describe('checkStepGoal', function () {
+      it('should return "Success!" when the latest numSteps is greater than or equal to dailyStepGoal', function () {
+        expect(checkStepGoal(currentUser1)).to.deep.equal('Success!');
+      });
+
+      it('should return "No!" when the latest numSteps is less than dailyStepGoal', function () {
+        expect(checkStepGoal(currentUser2)).to.deep.equal('No!');
+      });
+
+      it('should handle cases where activityData is empty, returning "No!"', function () {
+        expect(checkStepGoal(currentUser3)).to.deep.equal('No!');
+      });
+    });
+
+    describe('minutesActiveGivenDate', function () {
+      it('should return minutes active when the date is found', function () {
+        expect(minutesActiveGivenDate(currentUser1, '2023/03/24')).to.deep.equal(261);
+      });
+
+      it('should return undefined when the date is not found', function () {
+        expect(minutesActiveGivenDate(currentUser1, '2023/03/25')).to.be.undefined;
+      });
+
+      it('should return undefined when the activityData array is empty', function () {
+        expect(minutesActiveGivenDate(currentUser3, '2023/03/25')).to.be.undefined;
+      });
+    });
+
+    describe('numberOfStepsGivenDate', function () {
+      it('should return the number of steps when the date is found', function () {
+        expect(numberOfStepsGivenDate(currentUser2, '2023/03/28')).to.equal(5494);
+        expect(numberOfStepsGivenDate(currentUser2, '2023/03/29')).to.equal(6959);
+        expect(numberOfStepsGivenDate(currentUser2, '2023/03/30')).to.equal(4676);
+      });
+
+      it('should return undefined when the date is not found', function () {
+        expect(numberOfStepsGivenDate(currentUser1, '2023/03/28')).to.be.undefined;
+        expect(numberOfStepsGivenDate(currentUser1, '2023/03/29')).to.be.undefined;
+        expect(numberOfStepsGivenDate(currentUser1, '2023/03/30')).to.be.undefined;
+      });
+
+      it('should return undefined when the activityData array is empty', function () {
+        expect(numberOfStepsGivenDate(currentUser3, '2023/03/28')).to.be.undefined;
+        expect(numberOfStepsGivenDate(currentUser3, '2023/03/29')).to.be.undefined;
+        expect(numberOfStepsGivenDate(currentUser3, '2023/03/30')).to.be.undefined;
+      });
+    });
+
+    describe('checkStepGoal7Days', function () {
+
+      it('should return an array of objects containing date, numSteps, and metGoal properties', function () {
+        expect(checkStepGoal7Days(currentUser2)[0]).to.have.all.keys('date', 'numSteps', 'metGoal');
+      });
+
+      it('should return the correct metGoal values based on numSteps and dailyStepGoal for all 7 days', function () {
+        expect(checkStepGoal7Days(currentUser2)).to.deep.equal([
+          { date: '2023/03/30', numSteps: 4676, metGoal: 'Keep trying!' },
+          { date: '2023/03/29', numSteps: 6959, metGoal: 'Keep trying!' },
+          { date: '2023/03/28', numSteps: 5494, metGoal: 'Keep trying!' },
+          { date: '2023/03/27', numSteps: 12127, metGoal: 'You did it!' },
+          { date: '2023/03/26', numSteps: 9543, metGoal: 'You did it!' },
+          { date: '2023/03/25', numSteps: 14719, metGoal: 'You did it!' },
+          { date: '2023/03/24', numSteps: 3049, metGoal: 'Keep trying!' },
+        ]);
+      });
+
+      it('should handle users with no activityData, returning "No activity data available!"', function () {
+        expect(checkStepGoal7Days(currentUser3)).to.equal('No activity data available!');
+      });
     });
   });
-
-  describe('getHydrationFor7Days', function () {
-    it('should return hydration data for 7 days when data for all 7 days is available', function () {
-      const sevenDayHydration = getHydrationFor7Days(currentUser2, '2023/03/30');
-
-      expect(sevenDayHydration.length).to.deep.equal(7);
-      expect(sevenDayHydration).to.deep.equal([
-        { date: '2023/03/24', numOunces: 35 },
-        { date: '2023/03/25', numOunces: 92 },
-        { date: '2023/03/26', numOunces: 88 },
-        { date: '2023/03/27', numOunces: 88 },
-        { date: '2023/03/28', numOunces: 68 },
-        { date: '2023/03/29', numOunces: 50 },
-        { date: '2023/03/30', numOunces: 57 }
-      ]);
-    });
-
-    it('should return an empty array when no matching hydration data is found', function () {
-      const sevenDayHydration = getHydrationFor7Days(currentUser3, '2023/03/30');
-
-      expect(sevenDayHydration.length).to.deep.equal(0);
-      expect(sevenDayHydration).to.deep.equal([]);
-    });
-
-    it('should return partial data when only some of the 7 days have hydration data', function () {
-      const sevenDayHydration = getHydrationFor7Days(currentUser1, '2023/03/30');
-
-      expect(sevenDayHydration.length).to.deep.equal(1);
-      expect(sevenDayHydration).to.deep.equal([{ date: '2023/03/24', numOunces: 28 }]);
-    });
-  });
-
-  describe('calculateTotalHydration', function () {
-    it('should return 0 when there is no hydration data', function () {
-      expect(calculateTotalHydration(currentUser3)).to.deep.equal('0.00');
-    });
-
-    it('should return the average hydration when there is one hydration data entry', function () {
-      expect(calculateTotalHydration(currentUser1)).to.deep.equal('28.00');
-    });
-
-    it('should return the average hydration when there are multiple hydration data entries', function () {
-      expect(calculateTotalHydration(currentUser2)).to.deep.equal('68.29');
-    });
-  });
-
-  describe('distance traveled', function () {
-    it('should return the distance traveled by a user on the most recent day', function () {
-      expect(findDistanceTraveled(currentUser1)).to.deep.equal('5.58');
-      expect(findDistanceTraveled(currentUser2)).to.deep.equal('3.99');
-    });
-  });
-
-  describe('calculateAverageHoursSlept', function () {
-    it('should return 0 when there is no sleep data', function () {
-      expect(calculateTotalHydration(currentUser3)).to.deep.equal('0.00');
-    });
-
-    it('should return the average hours slept when there is one sleep data entry', function () {
-      expect(calculateAverageHoursSlept(currentUser1)).to.deep.equal('9.60');
-    });
-
-    it('should return the average hours slept when there are multiple sleep data entries', function () {
-      expect(calculateAverageHoursSlept(currentUser2)).to.deep.equal('8.07');
-    });
-  });
-
-  describe('calculateAverageSleepQuality', function () {
-    it('should return 0 when there is no sleep data', function () {
-      expect(calculateAverageSleepQuality(currentUser3)).to.deep.equal('0.00');
-    });
-
-    it('should return the average sleep quality when there is one sleep data entry', function () {
-      expect(calculateAverageSleepQuality(currentUser1)).to.deep.equal('4.30');
-    });
-
-    it('should return the average sleep quality when there are multiple sleep data entries', function () {
-      expect(calculateAverageSleepQuality(currentUser2)).to.deep.equal('3.33');
-    });
-  });
-
-  describe('hoursSleptGivenDate', function () {
-    it('should return hoursSlept when the date is found', function () {
-      expect(hoursSleptGivenDate(currentUser1, '2023/03/24')).to.deep.equal(9.60);
-    });
-
-    it('should return undefined when the date is not found', function () {
-      expect(hoursSleptGivenDate(currentUser1, '2023/03/25')).to.be.undefined;
-    });
-
-    it('should return undefined when the sleepData array is empty', function () {
-      expect(hoursSleptGivenDate(currentUser3, '2023/03/25')).to.be.undefined;
-    });
-  });
-
-  describe('sleepQualityGivenDate', function () {
-    it('should return sleepQuality when the date is found', function () {
-      expect(sleepQualityGivenDate(currentUser1, '2023/03/24')).to.deep.equal(4.30);
-    });
-
-    it('should return undefined when the date is not found', function () {
-      expect(sleepQualityGivenDate(currentUser1, '2023/03/25')).to.be.undefined;
-    });
-
-    it('should return undefined when the sleepData array is empty', function () {
-      expect(sleepQualityGivenDate(currentUser3, '2023/03/25')).to.be.undefined;
-    });
-  });
-
-  describe('getSleepQualityFor7Days', function () {
-    it('should return sleep quality data for 7 days when data is available', function () {
-      const sevenDaySleepQuality = getSleepQualityFor7Days(currentUser2, '2023/03/30');
-
-      expect(sevenDaySleepQuality.length).to.deep.equal(7);
-      expect(sevenDaySleepQuality).to.deep.equal([
-        { date: '2023/03/24', sleepQuality: 3.5 },
-        { date: '2023/03/25', sleepQuality: 4.7 },
-        { date: '2023/03/26', sleepQuality: 4.8 },
-        { date: '2023/03/27', sleepQuality: 2.8 },
-        { date: '2023/03/28', sleepQuality: 2.1 },
-        { date: '2023/03/29', sleepQuality: 2.2 },
-        { date: '2023/03/30', sleepQuality: 3.2 }
-      ]);
-    });
-
-    it('should return an empty array when no matching data is found', function () {
-      const sevenDaySleepQuality = getSleepQualityFor7Days(currentUser3, '2023/03/30');
-
-      expect(sevenDaySleepQuality.length).to.deep.equal(0);
-      expect(sevenDaySleepQuality).to.deep.equal([]);
-    });
-
-    it('should return partial data when only some days have sleep data', function () {
-      const sevenDaySleepQuality = getSleepQualityFor7Days(currentUser1, '2023/03/30');
-
-      expect(sevenDaySleepQuality.length).to.deep.equal(1);
-      expect(sevenDaySleepQuality).to.deep.equal([{ date: '2023/03/24', sleepQuality: 4.3 }]);
-    });
-  });
-
-  describe('getSleepFor7Days', function () {
-    it('should return sleep hours data for 7 days when data is available', function () {
-      const sevenDaySleep = getSleepFor7Days(currentUser2, '2023/03/30');
-
-      expect(sevenDaySleep).to.be.an('array');
-      expect(sevenDaySleep.length).to.deep.equal(7);
-      expect(sevenDaySleep).to.deep.equal([
-        { date: '2023/03/24', hoursSlept: 8.4 },
-        { date: '2023/03/25', hoursSlept: 8.1 },
-        { date: '2023/03/26', hoursSlept: 9.8 },
-        { date: '2023/03/27', hoursSlept: 10.7 },
-        { date: '2023/03/28', hoursSlept: 5.1 },
-        { date: '2023/03/29', hoursSlept: 4.3 },
-        { date: '2023/03/30', hoursSlept: 10.1 }
-      ]);
-    });
-
-    it('should return an empty array when no matching data is found', function () {
-      const sevenDaySleep = getSleepFor7Days(currentUser3, '2023/03/30');
-
-      expect(sevenDaySleep.length).to.deep.equal(0);
-      expect(sevenDaySleep).to.deep.equal([]);
-    });
-
-    it('should return partial data when only some days have sleep data', function () {
-      const sevenDaySleep = getSleepFor7Days(currentUser1, '2023/03/30');
-
-      expect(sevenDaySleep.length).to.deep.equal(1);
-      expect(sevenDaySleep).to.deep.equal([{ date: '2023/03/24', hoursSlept: 9.6 }]);
-    });
-  });
-
-  describe('checkStepGoal', function () {
-    it('should return "Success!" when the latest numSteps is greater than or equal to dailyStepGoal', function () {
-      expect(checkStepGoal(currentUser1)).to.deep.equal('Success!');
-    });
-
-    it('should return "No!" when the latest numSteps is less than dailyStepGoal', function () {
-      expect(checkStepGoal(currentUser2)).to.deep.equal('No!');
-    });
-
-    it('should handle cases where activityData is empty, returning "No!"', function () {
-      expect(checkStepGoal(currentUser3)).to.deep.equal('No!');
-    });
-  });
-
-  describe('minutesActiveGivenDate', function () {
-    it('should return minutes active when the date is found', function () {
-      expect(minutesActiveGivenDate(currentUser1, '2023/03/24')).to.deep.equal(261);
-    });
-
-    it('should return undefined when the date is not found', function () {
-      expect(minutesActiveGivenDate(currentUser1, '2023/03/25')).to.be.undefined;
-    });
-
-    it('should return undefined when the activityData array is empty', function () {
-      expect(minutesActiveGivenDate(currentUser3, '2023/03/25')).to.be.undefined;
-    });
-  });
-
-  describe('numberOfStepsGivenDate', function () {
-    it('should return the number of steps when the date is found', function () {
-      expect(numberOfStepsGivenDate(currentUser2, '2023/03/28')).to.equal(5494);
-      expect(numberOfStepsGivenDate(currentUser2, '2023/03/29')).to.equal(6959);
-      expect(numberOfStepsGivenDate(currentUser2, '2023/03/30')).to.equal(4676);
-    });
-
-    it('should return undefined when the date is not found', function () {
-      expect(numberOfStepsGivenDate(currentUser1, '2023/03/28')).to.be.undefined;
-      expect(numberOfStepsGivenDate(currentUser1, '2023/03/29')).to.be.undefined;
-      expect(numberOfStepsGivenDate(currentUser1, '2023/03/30')).to.be.undefined;
-    });
-
-    it('should return undefined when the activityData array is empty', function () {
-      expect(numberOfStepsGivenDate(currentUser3, '2023/03/28')).to.be.undefined;
-      expect(numberOfStepsGivenDate(currentUser3, '2023/03/29')).to.be.undefined;
-      expect(numberOfStepsGivenDate(currentUser3, '2023/03/30')).to.be.undefined;
-    });
-  });
-
-  describe('checkStepGoal7Days', function () {
-
-    it('should return an array of objects containing date, numSteps, and metGoal properties', function () {
-      expect(checkStepGoal7Days(currentUser2)[0]).to.have.all.keys('date', 'numSteps', 'metGoal');
-    });
-
-    it('should return the correct metGoal values based on numSteps and dailyStepGoal for all 7 days', function () {
-      expect(checkStepGoal7Days(currentUser2)).to.deep.equal([
-        { date: '2023/03/30', numSteps: 4676, metGoal: 'Keep trying!' },
-        { date: '2023/03/29', numSteps: 6959, metGoal: 'Keep trying!' },
-        { date: '2023/03/28', numSteps: 5494, metGoal: 'Keep trying!' },
-        { date: '2023/03/27', numSteps: 12127, metGoal: 'You did it!' },
-        { date: '2023/03/26', numSteps: 9543, metGoal: 'You did it!' },
-        { date: '2023/03/25', numSteps: 14719, metGoal: 'You did it!' },
-        { date: '2023/03/24', numSteps: 3049, metGoal: 'Keep trying!' },
-      ]);
-    });
-
-    it('should handle users with no activityData, returning "No activity data available!"', function () {
-      expect(checkStepGoal7Days(currentUser3)).to.equal('No activity data available!');
-    });
-  });
-})  

--- a/test/scripts-test.js
+++ b/test/scripts-test.js
@@ -7,7 +7,7 @@ describe('userObject creation', function () {
     const randomUserID = generateRandomUserID(users);
 
     expect(randomUserID).to.be.at.least(1);
-    expect(randomUserID).to.be.below(4);
+    expect(randomUserID).to.be.below(14);
   });
 
   it('should add hydration, activity, and sleep data to the currentUser', function () {
@@ -82,7 +82,7 @@ describe('get user info for admin', function () {
 
 describe('global average step goal', function () {
   it('should find the average step goal amongst all users', function () {
-    expect(findStepGoalAverage(users)).to.deep.equal('6333.33');
+    expect(findStepGoalAverage(users)).to.deep.equal('7230.77');
   });
 });
 
@@ -96,16 +96,58 @@ describe('bottom 10s', function () {
         userName: 'Colt Rohan'
       },
       {
+        userID: 12,
+        totalOunces: 24,
+        averageOunces: 24,
+        userName: 'Jacinthe Prosacco'
+      },
+      {
         userID: 1,
         totalOunces: 28,
         averageOunces: 28,
         userName: 'Trystan Gorczany'
       },
       {
-        userID: 2,
-        totalOunces: 478,
-        averageOunces: 68.28571428571429,
-        userName: 'Tyreek VonRueden'
+        userID: 8,
+        totalOunces: 36,
+        averageOunces: 36,
+        userName: 'Amir Lang'
+      },
+      {
+        userID: 9,
+        totalOunces: 40,
+        averageOunces: 40,
+        userName: 'Antonina McClure'
+      },
+      {
+        userID: 5,
+        totalOunces: 47,
+        averageOunces: 47,
+        userName: 'Brycen Rutherford'
+      },
+      {
+        userID: 11,
+        totalOunces: 48,
+        averageOunces: 48,
+        userName: 'Kailey Langosh'
+      },
+      {
+        userID: 10,
+        totalOunces: 49,
+        averageOunces: 49,
+        userName: 'Dianna Streich'
+      },
+      {
+        userID: 4,
+        totalOunces: 74,
+        averageOunces: 74,
+        userName: 'Evie Satterfield'
+      },
+      {
+        userID: 7,
+        totalOunces: 74,
+        averageOunces: 74,
+        userName: 'Elaina Mosciski'
       }
     ]);
   });
@@ -119,16 +161,58 @@ describe('bottom 10s', function () {
         userName: 'Colt Rohan'
       },
       {
-        userID: 1,
-        totalHoursSlept: 9.6,
-        averageHoursSlept: 9.6,
-        userName: 'Trystan Gorczany'
+        userID: 12,
+        totalHoursSlept: 4,
+        averageHoursSlept: 4,
+        userName: 'Jacinthe Prosacco'
       },
       {
-        userID: 2,
-        totalHoursSlept: 56.5,
-        averageHoursSlept: 8.071428571428571,
-        userName: 'Tyreek VonRueden'
+        userID: 7,
+        totalHoursSlept: 4.1,
+        averageHoursSlept: 4.1,
+        userName: 'Elaina Mosciski'
+      },
+      {
+        userID: 6,
+        totalHoursSlept: 4.2,
+        averageHoursSlept: 4.2,
+        userName: 'Jillian Senger'
+      },
+      {
+        userID: 4,
+        totalHoursSlept: 4.7,
+        averageHoursSlept: 4.7,
+        userName: 'Evie Satterfield'
+      },
+      {
+        userID: 9,
+        totalHoursSlept: 4.8,
+        averageHoursSlept: 4.8,
+        userName: 'Antonina McClure'
+      },
+      {
+        userID: 13,
+        totalHoursSlept: 6.5,
+        averageHoursSlept: 6.5,
+        userName: 'Seamus Upton'
+      },
+      {
+        userID: 10,
+        totalHoursSlept: 7.2,
+        averageHoursSlept: 7.2,
+        userName: 'Dianna Streich'
+      },
+      {
+        userID: 11,
+        totalHoursSlept: 7.2,
+        averageHoursSlept: 7.2,
+        userName: 'Kailey Langosh'
+      },
+      {
+        userID: 5,
+        totalHoursSlept: 8,
+        averageHoursSlept: 8,
+        userName: 'Brycen Rutherford'
       }
     ]);
   });
@@ -142,16 +226,58 @@ describe('bottom 10s', function () {
         userName: 'Colt Rohan'
       },
       {
+        userID: 10,
+        totalSteps: 2145,
+        averageSteps: 2145,
+        userName: 'Dianna Streich'
+      },
+      {
+        userID: 9,
+        totalSteps: 3801,
+        averageSteps: 3801,
+        userName: 'Antonina McClure'
+      },
+      {
+        userID: 11,
+        totalSteps: 5491,
+        averageSteps: 5491,
+        userName: 'Kailey Langosh'
+      },
+      {
+        userID: 8,
+        totalSteps: 7255,
+        averageSteps: 7255,
+        userName: 'Amir Lang'
+      },
+      {
         userID: 1,
         totalSteps: 7362,
         averageSteps: 7362,
         userName: 'Trystan Gorczany'
       },
       {
-        userID: 2,
-        totalSteps: 56567,
-        averageSteps: 8081,
-        userName: 'Tyreek VonRueden'
+        userID: 7,
+        totalSteps: 7765,
+        averageSteps: 7765,
+        userName: 'Elaina Mosciski'
+      },
+      {
+        userID: 5,
+        totalSteps: 8443,
+        averageSteps: 8443,
+        userName: 'Brycen Rutherford'
+      },
+      {
+        userID: 4,
+        totalSteps: 8934,
+        averageSteps: 8934,
+        userName: 'Evie Satterfield'
+      },
+      {
+        userID: 12,
+        totalSteps: 11616,
+        averageSteps: 11616,
+        userName: 'Jacinthe Prosacco'
       }
     ]);
   });


### PR DESCRIPTION
# Description
Three functions were written for our bottom 10s lists, but tests were not added at the time. This PR catches up.
- Add tests for `findBottomDrinkers`
- Add tests for `findBottomSleepers`
- Add tests for `findBottomStepTakers`
- Add data to `/src/data/testData.js` so the tests have to calculate for more than 10 users and sort out the bottom 10
  - Note that this required a couple of other test tweaks because the added data changed some values in the tests (`generateRandomUserID` and `findStepGoalAverage` specifically).

# Contributors
@ericahagle 

# Notes
- I think some stuff might _appear_ to be changes, but are actually just caused by where I put the tests. Some line reconciliation, but not actual changes to the rest of the tests. The only actual changes are called out in the PR description.
- I couldn't think of a good way to add sad paths for these. I know that If there are fewer than 10, it'll just return all the available records, because I tested it when there were only the three users in our test data. But I don't know that it's worth it to jump through hoops to recreate that now that I bumped up the test data.

# Checklist
- [x] My PR has an appropriately descriptive and concise title.
- [x] My PR denotes any/all team members who contributed to it.
- [x] My code follows the Turing Style Guides and best practices.
- [x] I ran the code locally and verified that there are no visible errors.
- [x] test: My PR clearly describes what tests I'm adding and any why.